### PR TITLE
Fixes conflict with latest macOS Sierra keyboards

### DIFF
--- a/cf.keylayout
+++ b/cf.keylayout
@@ -10,7 +10,7 @@
   <https://github.com/ergosteur/cf-keylayout>
 -->
 
-<keyboard group="0" id="5000" name="Canadien francais 0.11" maxout="1">
+<keyboard group="0" id="16383" name="Canadien francais 0.11" maxout="1">
         <layouts>
                 <layout first="0" last="0" modifiers="48" mapSet="312" />
         </layouts>

--- a/cf.keylayout
+++ b/cf.keylayout
@@ -10,7 +10,7 @@
   <https://github.com/ergosteur/cf-keylayout>
 -->
 
-<keyboard group="0" id="16383" name="Canadien francais 0.11" maxout="1">
+<keyboard group="0" id="10122" name="Canadien francais 0.11" maxout="1">
         <layouts>
                 <layout first="0" last="0" modifiers="48" mapSet="312" />
         </layouts>

--- a/cf.keylayout
+++ b/cf.keylayout
@@ -10,7 +10,7 @@
   <https://github.com/ergosteur/cf-keylayout>
 -->
 
-<keyboard group="0" id="10122" name="Canadien francais 0.11" maxout="1">
+<keyboard group="0" id="9960" name="Canadien francais 0.11" maxout="1">
         <layouts>
                 <layout first="0" last="0" modifiers="48" mapSet="312" />
         </layouts>


### PR DESCRIPTION
When booting in macOS Sierra using this keyboard layout, the OS reinitialize the keyboard layout back to the default

Running the command "sudo touch /Library/Keyboard\ Layouts/" explains the conflict and suggest the keyboard id "16383".