### PR TITLE
`Alt` + Espace: *Non-breaking space* (U+00A0) => *Space* (U+0020)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,19 @@ Installation
 3. After the installation, the Keyboard system preferences screen will
    open. Go to the Input Sources tab and add the "Canadien Francais"
    keyboard to your account.
-   
+
 *Todo: Brew installation (PR welcome!)*
+
+Changements en rupture  (*Breaking changes*)
+----------------------
+* `Alt` + Space: From *Non-breaking space* (U+00A0) to *Space* (U+0020)
+
+    Utiliser la touche Alt juste avant *Espace* créait facilement
+    une espace insécable sans le vouloir. Dans un contexte de programmation,
+    ça peut causer problème.
+
+    Le *nbsp* est toujours disponible avec `Alt` + `Shift` + *Espace*, une
+    combinaison plus délibérée.
 
 Recipes and protips
 -------------------
@@ -21,7 +32,7 @@ Recipe                 | Output      | Comments
 `` ` ``, `a`           | `à`         | Voyelles accent grave
 `` ^ ``, `Shift` + `A` | `Â`         |
                        |             | 
-`Alt` + Space          | ` `         | Non-breaking space (nbsp – u+00a0) **\***
+`Alt` + `Shift` + Space | ` `         | Non-breaking space (nbsp – u+00a0) **\***
 `Alt` + `` ` ``        | `{`         |
 `Alt` + `<`            | `}`         |
 `Alt` + `-`            | `–`         | En-dash/tiret moyen/demi-cadratin
@@ -34,7 +45,7 @@ Recipe                 | Output      | Comments
 `Shift` + `^`          | `^`         | Pas besoin de faire espace après
 `Shift` + `` ` ``      | `` ` ``     | (même principe)
 
-\[\*]: Non-breaking space: Attention avec ceci. C'est facile d'en taper une sans s'en rendre compte. Ça explique parfois bogues étranges de programmation et de rédaction. Ex.: "No method named ' foo'.
+\[\*]: Non-breaking space: Attention avec ceci. Ça explique parfois bogues étranges de programmation et de rédaction. Ex.: "No method named ' foo'.
 
 Vim users: `é` can be a good leader key. `let mapleader = "é"`
 

--- a/cf.keylayout
+++ b/cf.keylayout
@@ -419,7 +419,7 @@
                         <key code="46" output="&#xb5;" />
                         <key code="47" output="&#xB7;" />
                         <key code="48" output="&#x9;" />
-                        <key code="49" output="&#xA0;" />
+                        <key code="49" output=" " />
                         <key code="50" output="\" />
                         <key code="51" output="&#x8;" />
                         <key code="52" output="&#x3;" />
@@ -541,7 +541,7 @@
                         <key code="46" output="&#xb5;" />
                         <key code="47" output="&#xB7;" />
                         <key code="48" output="&#x9;" />
-                        <key code="49" output="&#xA0;" />
+                        <key code="49" output=" " />
                         <key code="50" output="\" />
                         <key code="51" output="&#x8;" />
                         <key code="52" output="&#x3;" />


### PR DESCRIPTION
Je gratte quelque chose qui me démange depuis un bout: l'espace insécable.

## Motivation

Tellement souvent ça m'est arrivé de taper du code du genre:

```console
> 10.times{ dance(MACARENA) }
```

Pendant qu'on est distrait par la grande danse de la programmation, et soudain, ceci arrive

```
NoMethodError: undefined method ` dance' for main:Object
Did you mean?  dance
```

Eh oui, parmi tout ce fracas, un nbsp ` ` s'est inséré au début du bloc entre `{` et `d`.

**Il est facile de taper l'espace insécable par accident.**

## Proposition

De ramener Alt+Espace à une espace normal, et garder Alt+Shift+Espace pour le nbsp.

On réduirait les faux positifs, tout en gardant le nbsp à portée de la main pour ces moments où il est incroyablement utile.

Ça veut par contre dire que d'enlever Alt+Espace est un **breaking change**.

---

<small>

```plain
# macarena.rb

MACARENA = "^^  vv  **  __  ~~~~ EH MACARENA!  |\n\n"

def dance(dance)
  puts "+ #{dance}"
end

10.times{ dance(MACARENA) }
```