### PR TITLE
#29 Accent espace

### DIFF
--- a/cf.keylayout
+++ b/cf.keylayout
@@ -10,7 +10,7 @@
   <https://github.com/ergosteur/cf-keylayout>
 -->
 
-<keyboard group="0" id="9960" name="Canadien français 0.12.1" maxout="1">
+<keyboard group="0" id="9960" name="Canadien français 0.12.3 Corrected" maxout="1">
         <layouts>
                 <layout first="0" last="0" modifiers="48" mapSet="312" />
         </layouts>
@@ -91,7 +91,7 @@
                         <key code="46" output="m" />
                         <key code="47" output="." />
                         <key code="48" output="&#x9;" />
-                        <key code="49" output=" " />
+                        <key code="49" action="space" />
                         <key code="50" output="#" />
                         <key code="51" output="&#x8;" />
                         <key code="52" output="&#x3;" />
@@ -784,6 +784,13 @@
                 <action id="trema">
                      <when state="none" next="trema" />
                 </action>
+		<action id="space">
+		     <when state="none" output=" " />
+                     <when state="grave" output="&#x60;" />
+                     <when state="circumflex" output="&#x5e;" />
+                     <when state="trema" output="&#xa8;" />
+                     <when state="cedille" output="&#xb8;" />
+                </action>
                 <action id="a">
                      <when state="none" output="a" />
                      <when state="grave" output="&#xe0;" />
@@ -849,10 +856,4 @@
                      <when state="trema" output="&#xdc;" />
                 </action>
         </actions>
-        <terminators>
-            <when state="cedille" output="&#xb8;" />
-            <when state="circumflex" output="&#x5e;" />
-            <when state="grave" output="&#x60;" />
-            <when state="trema" output="&#xa8;" />
-        </terminators>
 </keyboard>

--- a/cf.keylayout
+++ b/cf.keylayout
@@ -10,7 +10,7 @@
   <https://github.com/ergosteur/cf-keylayout>
 -->
 
-<keyboard group="0" id="9960" name="Canadien français 0.12.3 Corrected" maxout="1">
+<keyboard group="0" id="9960" name="Canadien français 0.12.1" maxout="1">
         <layouts>
                 <layout first="0" last="0" modifiers="48" mapSet="312" />
         </layouts>
@@ -856,4 +856,10 @@
                      <when state="trema" output="&#xdc;" />
                 </action>
         </actions>
+        <terminators>
+            <when state="cedille" output="&#xb8;" />
+            <when state="circumflex" output="&#x5e;" />
+            <when state="grave" output="&#x60;" />
+            <when state="trema" output="&#xa8;" />
+        </terminators>
 </keyboard>


### PR DESCRIPTION
Fixes #29

Ce PR fait en sorte que entrer la combinaisons 'accent' + 'espace' (e.g. '^' + 'espace') donne comme resultat uniquement l'accent au lieu de l'accent suivi du caractere espace, ce qui est le comportement sur Linux et Windows.